### PR TITLE
fix broken link

### DIFF
--- a/leaders.md
+++ b/leaders.md
@@ -7,5 +7,5 @@
 * [OWASP Threat Model Project](https://wiki.owasp.org/index.php/OWASP_Threat_Model_Project)
 * [OWASP PyTM](https://github.com/OWASP/pytm)
 * [OWASP Threat Dragon](https://owasp.org/www-project-threat-dragon/)
-* [Threat Modeling Cheat Sheet](https://owasp.org/www-project-cheat-sheets/cheatsheets/Third_Party_Javascript_Management_Cheat_Sheet.html)
+* [Threat Modeling Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Threat_Modeling_Cheat_Sheet.html)
 


### PR DESCRIPTION
The existing link to Threat Modeling Cheat Sheet gives 404 - I think this is the corrected link